### PR TITLE
add modal for initial import of QFeatures (processQFeatures)

### DIFF
--- a/R/build_process_server.R
+++ b/R/build_process_server.R
@@ -43,9 +43,27 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
 
         uploaded_qfeatures <- shiny::reactiveVal(NULL)
         upload_message <- shiny::reactiveVal(NULL)
+        startup_reading <- shiny::reactiveVal(FALSE)
+
+        output$startup_initial_sets_label <- shiny::renderText({
+            uploaded <- uploaded_qfeatures()
+            if (is.null(uploaded)) {
+                return("Initial sets")
+            }
+
+            selected_sets <- input$startup_initial_sets
+            if (is.null(selected_sets)) {
+                selected_sets <- names(uploaded)
+            }
+
+            paste0("Initial sets (", length(selected_sets), " selected)")
+        })
 
         output$startup_initial_sets_ui <- shiny::renderUI({
             uploaded <- uploaded_qfeatures()
+            if (startup_reading()) {
+                return(NULL)
+            }
             if (is.null(uploaded)) {
                 return(shiny::p(
                     "Upload an .rds file containing a QFeatures object to",
@@ -53,16 +71,23 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                 ))
             }
 
-            shiny::selectizeInput(
-                "startup_initial_sets",
-                "Initial sets",
-                choices = names(uploaded),
-                selected = names(uploaded),
-                multiple = TRUE,
-                width = "100%",
-                options = list(
-                    plugins = list("remove_button"),
-                    placeholder = "Choose one or more initial sets"
+            shiny::tagList(
+                shiny::tags$label(
+                    `for` = "startup_initial_sets",
+                    class = "control-label",
+                    shiny::textOutput("startup_initial_sets_label", inline = TRUE)
+                ),
+                shiny::selectizeInput(
+                    "startup_initial_sets",
+                    NULL,
+                    choices = names(uploaded),
+                    selected = names(uploaded),
+                    multiple = TRUE,
+                    width = "100%",
+                    options = list(
+                        plugins = list("remove_button"),
+                        placeholder = "Choose one or more initial sets"
+                    )
                 )
             )
         })
@@ -73,6 +98,29 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                 return(NULL)
             }
             shiny::tags$div(class = "text-danger", msg)
+        })
+
+        output$startup_read_status <- shiny::renderUI({
+            if (!startup_reading()) {
+                return(NULL)
+            }
+
+            shiny::tags$div(
+                class = "qfeatures-startup-read-status",
+                shiny::tags$div(
+                    class = "progress",
+                    shiny::tags$div(
+                        class = "progress-bar progress-bar-striped active",
+                        role = "progressbar",
+                        style = "width: 100%;"
+                    )
+                ),
+                shiny::tags$p(
+                    shiny::tags$em(
+                        "Reading QFeatures object. This can take some time for large files."
+                    )
+                )
+            )
         })
 
         show_startup_upload_modal <- function() {
@@ -89,6 +137,7 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                     accept = c(".rds", ".Rds", ".RDS")
                 ),
                 shiny::uiOutput("startup_initial_sets_ui"),
+                shiny::uiOutput("startup_read_status"),
                 shiny::uiOutput("startup_upload_message"),
                 easyClose = FALSE,
                 size = "l",
@@ -106,20 +155,25 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
         shiny::observeEvent(input$startup_qfeatures_rds, {
             uploaded_qfeatures(NULL)
             upload_message(NULL)
+            startup_reading(TRUE)
+            datapath <- input$startup_qfeatures_rds$datapath
 
-            uploaded <- tryCatch(
-                check_qfeatures(input$startup_qfeatures_rds$datapath),
-                error = function(e) e
-            )
-            if (inherits(uploaded, "error")) {
-                upload_message(paste(
-                    "Could not load QFeatures object:",
-                    conditionMessage(uploaded)
-                ))
-                return(invisible(NULL))
-            }
+            session$onFlushed(function() {
+                uploaded <- tryCatch(
+                    check_qfeatures(datapath),
+                    error = function(e) e
+                )
+                startup_reading(FALSE)
+                if (inherits(uploaded, "error")) {
+                    upload_message(paste(
+                        "Could not load QFeatures object:",
+                        conditionMessage(uploaded)
+                    ))
+                    return(invisible(NULL))
+                }
 
-            uploaded_qfeatures(uploaded)
+                uploaded_qfeatures(uploaded)
+            }, once = TRUE)
         }, ignoreInit = TRUE)
 
         shiny::observeEvent(input$startup_load_qfeatures, {

--- a/R/build_process_server.R
+++ b/R/build_process_server.R
@@ -3,6 +3,8 @@
 #' @param qfeatures a `QFeatures` object given by the user
 #' @param initial_sets index of the base sets of the QFeatures
 #' @param initial_steps prefilled workflow steps
+#' @param has_qfeatures `logical(1)` indicating whether the app was launched
+#'   with an initial QFeatures object
 #'
 #' @return return the server function for the processQFeatures app.
 #' @rdname INTERNAL_build_process_server
@@ -13,7 +15,7 @@
 #' @importFrom shinydashboard updateTabItems
 #' @importFrom shinyalert shinyalert
 #'
-build_process_server <- function(qfeatures, initial_sets, initial_steps) {
+build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfeatures = TRUE) {
     server <- function(input, output, session) {
         global_rv$exception_data <- data.frame(
             id = character(),
@@ -25,14 +27,162 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps) {
             time = as.POSIXct(character()),
             stringsAsFactors = FALSE
         )
-        .qf$qfeatures <- format_qfeatures(qfeatures, initial_sets)
-        global_rv$workflow_config <- initial_steps
+        .qf$qfeatures <- if (has_qfeatures) {
+            format_qfeatures(qfeatures, initial_sets)
+        } else {
+            NULL
+        }
+        global_rv$workflow_config <- if (has_qfeatures) initial_steps else character(0)
         global_rv$code_lines <- list()
+        global_rv$step_rvs <- list()
         server_exception_menu(input, output, session)
         server_sidebar(input, output, session)
         server_module_workflow_config("workflow_config")
         server_dynamic_workflow(input, output, session)
         server_module_summary_tab("summary_tab")
+
+        uploaded_qfeatures <- shiny::reactiveVal(NULL)
+        upload_message <- shiny::reactiveVal(NULL)
+
+        output$startup_initial_sets_ui <- shiny::renderUI({
+            uploaded <- uploaded_qfeatures()
+            if (is.null(uploaded)) {
+                return(shiny::p(
+                    "Upload an .rds file containing a QFeatures object to",
+                    "choose the initial sets."
+                ))
+            }
+
+            shiny::selectizeInput(
+                "startup_initial_sets",
+                "Initial sets",
+                choices = names(uploaded),
+                selected = names(uploaded),
+                multiple = TRUE,
+                width = "100%",
+                options = list(
+                    plugins = list("remove_button"),
+                    placeholder = "Choose one or more initial sets"
+                )
+            )
+        })
+
+        output$startup_upload_message <- shiny::renderUI({
+            msg <- upload_message()
+            if (is.null(msg)) {
+                return(NULL)
+            }
+            shiny::tags$div(class = "text-danger", msg)
+        })
+
+        show_startup_upload_modal <- function() {
+            shiny::showModal(shiny::modalDialog(
+                title = "Load a QFeatures object",
+                shiny::p(
+                    "processQFeatures was started without a QFeatures object.",
+                    "Upload an .rds file containing one, then choose which",
+                    "sets should be used as the initial sets."
+                ),
+                shiny::fileInput(
+                    "startup_qfeatures_rds",
+                    "QFeatures RDS file",
+                    accept = c(".rds", ".Rds", ".RDS")
+                ),
+                shiny::uiOutput("startup_initial_sets_ui"),
+                shiny::uiOutput("startup_upload_message"),
+                easyClose = FALSE,
+                size = "l",
+                footer = shiny::tagList(
+                    shiny::modalButton("Cancel"),
+                    shiny::actionButton(
+                        "startup_load_qfeatures",
+                        "Load QFeatures",
+                        class = "btn-primary"
+                    )
+                )
+            ))
+        }
+
+        shiny::observeEvent(input$startup_qfeatures_rds, {
+            uploaded_qfeatures(NULL)
+            upload_message(NULL)
+
+            uploaded <- tryCatch(
+                check_qfeatures(input$startup_qfeatures_rds$datapath),
+                error = function(e) e
+            )
+            if (inherits(uploaded, "error")) {
+                upload_message(paste(
+                    "Could not load QFeatures object:",
+                    conditionMessage(uploaded)
+                ))
+                return(invisible(NULL))
+            }
+
+            uploaded_qfeatures(uploaded)
+        }, ignoreInit = TRUE)
+
+        shiny::observeEvent(input$startup_load_qfeatures, {
+            uploaded <- uploaded_qfeatures()
+            if (is.null(uploaded)) {
+                upload_message(
+                    "Upload a valid .rds file containing a QFeatures object."
+                )
+                return(invisible(NULL))
+            }
+
+            selected_sets <- input$startup_initial_sets
+            initial_idx <- tryCatch(
+                normalise_initial_sets(uploaded, selected_sets),
+                error = function(e) e
+            )
+            if (inherits(initial_idx, "error")) {
+                upload_message(conditionMessage(initial_idx))
+                return(invisible(NULL))
+            }
+
+            workflow_steps <- input[["workflow_config-workflow_list"]]
+            if (is.null(workflow_steps)) {
+                workflow_steps <- initial_steps
+            }
+
+            .qf$qfeatures <- format_qfeatures(uploaded, initial_idx)
+            global_rv$workflow_config <- workflow_steps
+            global_rv$code_lines <- list()
+            shiny::removeModal()
+
+            n_sets <- length(initial_idx)
+            n_steps <- length(workflow_steps)
+            shinyalert(
+                title = "QFeatures loaded",
+                text = paste0(
+                    "Loaded QFeatures with ", n_sets,
+                    " initial set", if (n_sets != 1) "s" else "", ".",
+                    if (n_steps > 0) {
+                        paste0(
+                            "\nWorkflow pre-configured with ", n_steps,
+                            " step", if (n_steps != 1) "s" else "", "."
+                        )
+                    } else {
+                        ""
+                    }
+                ),
+                closeOnClickOutside = TRUE,
+                type = "success",
+                confirmButtonCol = "#3c8dbc"
+            )
+        }, ignoreInit = TRUE)
+
+        shiny::observeEvent(input$startup_show_upload, {
+            show_startup_upload_modal()
+        }, ignoreInit = TRUE)
+
+        if (!has_qfeatures) {
+            session$onFlushed(function() {
+                show_startup_upload_modal()
+            }, once = TRUE)
+            return(invisible(NULL))
+        }
 
         n_sets <- length(initial_sets)
         n_steps <- length(initial_steps)

--- a/R/processQFeatures.R
+++ b/R/processQFeatures.R
@@ -9,9 +9,10 @@
 #' \linkS4class{QFeatures} object or as a path to an \code{.rds} file
 #' containing one.
 #'
-#' @param qfeatures A \linkS4class{QFeatures} object to be processed,
+#' @param qfeatures Optional \linkS4class{QFeatures} object to be processed,
 #'   or a character string specifying the path to a \code{.rds} file
-#'   containing a \linkS4class{QFeatures} object.
+#'   containing a \linkS4class{QFeatures} object. If omitted, the app starts
+#'   without processing steps and displays a startup modal.
 #'
 #' @param initialSets An integer, logical, or character vector specifying
 #'   which assays (feature sets) should be used as the starting point for
@@ -60,8 +61,8 @@
 #'     shiny::runApp(app)
 #' }
 processQFeatures <- function(
-      qfeatures,
-      initialSets = seq_along(qfeatures),
+      qfeatures = NULL,
+      initialSets = NULL,
       prefilledSteps = c(
           "sampleFiltering",
           "featureFiltering",
@@ -73,14 +74,21 @@ processQFeatures <- function(
           "aggregation"
       )
 ) {
-    ## Validate QFeatures input
-    qfeatures <- check_qfeatures(qfeatures)
-
-    ## Normalize initial assay selection
-    initial_sets <- normalise_initial_sets(qfeatures, initialSets)
-
-    ## Validate and map workflow steps
+    qfeatures_missing <- missing(qfeatures) || is.null(qfeatures)
     initial_steps <- check_prefilled_steps(prefilledSteps)
+
+    if (qfeatures_missing) {
+        initial_sets <- integer(0)
+    } else {
+        ## Validate QFeatures input
+        qfeatures <- check_qfeatures(qfeatures)
+
+        ## Normalize initial assay selection
+        if (is.null(initialSets)) {
+            initialSets <- seq_along(qfeatures)
+        }
+        initial_sets <- normalise_initial_sets(qfeatures, initialSets)
+    }
 
     options(shiny.maxRequestSize = 100 * 1024^2)
     addResourcePath(
@@ -89,7 +97,12 @@ processQFeatures <- function(
     )
 
     ui <- build_process_ui(initial_steps)
-    server <- build_process_server(qfeatures, initial_sets, initial_steps)
+    server <- build_process_server(
+        qfeatures,
+        initial_sets,
+        initial_steps,
+        has_qfeatures = !qfeatures_missing
+    )
 
     shinyApp(ui = ui, server = server)
 }

--- a/R/processQFeatures.R
+++ b/R/processQFeatures.R
@@ -5,9 +5,10 @@
 #' that allows users to visually configure and apply pre-processing
 #' workflows to a \linkS4class{QFeatures} object.
 #'
-#' The input \code{qfeatures} can be provided either as an in-memory
-#' \linkS4class{QFeatures} object or as a path to an \code{.rds} file
-#' containing one.
+#' The input \code{qfeatures} can be provided as an in-memory
+#' \linkS4class{QFeatures} object, as a path to an \code{.rds} file
+#' containing one, or omitted. If omitted, the application prompts the user
+#' to upload a \linkS4class{QFeatures} object from an \code{.rds} file.
 #'
 #' @param qfeatures Optional \linkS4class{QFeatures} object to be processed,
 #'   or a character string specifying the path to a \code{.rds} file
@@ -16,12 +17,18 @@
 #'
 #' @param initialSets An integer, logical, or character vector specifying
 #'   which assays (feature sets) should be used as the starting point for
-#'   processing. Defaults to all assays in \code{qfeatures}.
+#'   processing. If \code{NULL} and \code{qfeatures} is provided, all assays in
+#'   \code{qfeatures} are used. If \code{qfeatures} is omitted, the user chooses
+#'   the initial sets after uploading the \code{.rds} file.
 #'
 #' @param prefilledSteps A character vector specifying the initial workflow
 #'   steps to display when the application launches. Steps must be provided
 #'   using their internal identifiers (e.g. \code{"sampleFiltering"},
 #'   \code{"featureFiltering"}, \code{"normalisation"}).
+#'
+#' @param maxSize An integer that changes the \code{shiny.maxRequestSize}
+#'   value, in MB. This controls the maximum upload size for the startup
+#'   \code{.rds} file upload modal.
 #'
 #' @return
 #' The processQFeatures Shiny application.
@@ -34,7 +41,7 @@
 #'
 #' @export
 #'
-#' @importFrom shiny shinyApp runApp addResourcePath
+#' @importFrom shiny shinyApp runApp addResourcePath onStop
 #'
 #' @examples
 #'
@@ -54,7 +61,8 @@
 #'
 #' app <- processQFeatures(
 #'     qfeatures,
-#'     initialSets = seq_along(qfeatures)
+#'     initialSets = seq_along(qfeatures),
+#'     maxSize = 100
 #' )
 #'
 #' if (interactive()) {
@@ -72,7 +80,8 @@ processQFeatures <- function(
           "aggregation",
           "join",
           "aggregation"
-      )
+      ),
+      maxSize = 100
 ) {
     qfeatures_missing <- missing(qfeatures) || is.null(qfeatures)
     initial_steps <- check_prefilled_steps(prefilledSteps)
@@ -90,7 +99,8 @@ processQFeatures <- function(
         initial_sets <- normalise_initial_sets(qfeatures, initialSets)
     }
 
-    options(shiny.maxRequestSize = 100 * 1024^2)
+    oldOptions <- options(shiny.maxRequestSize = maxSize * 1024^2)
+    onStop(function() options(oldOptions))
     addResourcePath(
         "app-assets",
         system.file("www", package = "QFeaturesGUI")

--- a/R/server_module_workflow_config.R
+++ b/R/server_module_workflow_config.R
@@ -25,6 +25,30 @@ server_module_workflow_config <- function(id) {
         pending_config <- reactiveVal(NULL)
 
         observeEvent(input$apply, {
+            if (is.null(.qf$qfeatures)) {
+                showModal(modalDialog(
+                    title = "No QFeatures object loaded",
+                    p(
+                        "Workflow steps cannot be configured because no",
+                        "QFeatures object was provided when the app started."
+                    ),
+                    p(
+                        "Upload an .rds file containing a QFeatures object",
+                        "and choose the initial sets before applying a workflow."
+                    ),
+                    easyClose = TRUE,
+                    footer = tagList(
+                        modalButton("Cancel"),
+                        actionButton(
+                            "startup_show_upload",
+                            "Upload QFeatures",
+                            class = "btn-primary"
+                        )
+                    )
+                ))
+                return(invisible(NULL))
+            }
+
             any_saved <- !is.null(global_rv$step_rvs) &&
                 any(vapply(global_rv$step_rvs, function(rv) rv() > 0L, logical(1)))
 

--- a/R/utils_processQFeatures.R
+++ b/R/utils_processQFeatures.R
@@ -198,7 +198,9 @@ check_qfeatures <- function(qfeatures) {
         stop("`qfeatures` argument is missing")
     }
 
+    from_rds_file <- FALSE
     if (is.character(qfeatures)) {
+        from_rds_file <- TRUE
         if (length(qfeatures) != 1L) {
             stop("`qfeatures` must be a single path to an RDS file.")
         }
@@ -215,6 +217,9 @@ check_qfeatures <- function(qfeatures) {
     }
 
     if (!inherits(qfeatures, "QFeatures")) {
+        if (from_rds_file) {
+            stop("The RDS file does not contain a QFeatures object.")
+        }
         stop(
             "`qfeatures` must be a QFeatures object or a valid path to an RDS file containing one."
         )

--- a/man/processQFeatures.Rd
+++ b/man/processQFeatures.Rd
@@ -5,25 +5,33 @@
 \title{Launch a Shiny application to process QFeatures objects}
 \usage{
 processQFeatures(
-  qfeatures,
-  initialSets = seq_along(qfeatures),
+  qfeatures = NULL,
+  initialSets = NULL,
   prefilledSteps = c("sampleFiltering", "featureFiltering", "missingValuesFeatures",
-    "missingValuesSamples", "normalisation", "aggregation", "join", "aggregation")
+    "missingValuesSamples", "normalisation", "aggregation", "join", "aggregation"),
+  maxSize = 100
 )
 }
 \arguments{
-\item{qfeatures}{A \linkS4class{QFeatures} object to be processed,
+\item{qfeatures}{Optional \linkS4class{QFeatures} object to be processed,
 or a character string specifying the path to a \code{.rds} file
-containing a \linkS4class{QFeatures} object.}
+containing a \linkS4class{QFeatures} object. If omitted, the app starts
+without processing steps and displays a startup modal.}
 
 \item{initialSets}{An integer, logical, or character vector specifying
 which assays (feature sets) should be used as the starting point for
-processing. Defaults to all assays in \code{qfeatures}.}
+processing. If \code{NULL} and \code{qfeatures} is provided, all assays in
+\code{qfeatures} are used. If \code{qfeatures} is omitted, the user chooses
+the initial sets after uploading the \code{.rds} file.}
 
 \item{prefilledSteps}{A character vector specifying the initial workflow
 steps to display when the application launches. Steps must be provided
 using their internal identifiers (e.g. \code{"sampleFiltering"},
 \code{"featureFiltering"}, \code{"normalisation"}).}
+
+\item{maxSize}{An integer that changes the \code{shiny.maxRequestSize}
+value, in MB. This controls the maximum upload size for the startup
+\code{.rds} file upload modal.}
 }
 \value{
 The processQFeatures Shiny application.
@@ -33,9 +41,10 @@ The processQFeatures Shiny application.
 that allows users to visually configure and apply pre-processing
 workflows to a \linkS4class{QFeatures} object.
 
-The input \code{qfeatures} can be provided either as an in-memory
-\linkS4class{QFeatures} object or as a path to an \code{.rds} file
-containing one.
+The input \code{qfeatures} can be provided as an in-memory
+\linkS4class{QFeatures} object, as a path to an \code{.rds} file
+containing one, or omitted. If omitted, the application prompts the user
+to upload a \linkS4class{QFeatures} object from an \code{.rds} file.
 }
 \details{
 The application provides a drag-and-drop workflow builder that allows
@@ -61,7 +70,8 @@ qfeatures <- readQFeatures(
 
 app <- processQFeatures(
     qfeatures,
-    initialSets = seq_along(qfeatures)
+    initialSets = seq_along(qfeatures),
+    maxSize = 100
 )
 
 if (interactive()) {

--- a/tests/testthat/test-processQFeatures.R
+++ b/tests/testthat/test-processQFeatures.R
@@ -1,0 +1,5 @@
+test_that("processQFeatures can be constructed without a QFeatures object", {
+    app <- processQFeatures()
+
+    expect_s3_class(app, "shiny.appobj")
+})

--- a/tests/testthat/test-utils-processQFeatures.R
+++ b/tests/testthat/test-utils-processQFeatures.R
@@ -69,7 +69,7 @@ test_that("check_qfeatures validates objects and RDS paths", {
     saveRDS(data.frame(x = 1), bad_path)
     expect_error(
         check_qfeatures(bad_path),
-        "must be a QFeatures object"
+        "RDS file does not contain a QFeatures object"
     )
 })
 


### PR DESCRIPTION
- Modal appears when no QFeatures is provided to the `processQFeatures` function.
- User can then load an RDS file that needs to be a QFeatures object (error message otherwise)
- User can then choose which sets should be used as the initial serie of set to process.