### PR TITLE
add demo QFeatures for processQFeatures

### DIFF
--- a/R/build_process_server.R
+++ b/R/build_process_server.R
@@ -128,8 +128,8 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                 title = "Load a QFeatures object",
                 shiny::p(
                     "processQFeatures was started without a QFeatures object.",
-                    "Upload an .rds file containing one, then choose which",
-                    "sets should be used as the initial sets."
+                    "Upload an .rds file and choose initial sets, or start",
+                    "with the bundled demo."
                 ),
                 shiny::fileInput(
                     "startup_qfeatures_rds",
@@ -144,12 +144,60 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                 footer = shiny::tagList(
                     shiny::modalButton("Cancel"),
                     shiny::actionButton(
+                        "startup_use_demo_qfeatures",
+                        "Use demo QFeatures",
+                        class = "btn-default"
+                    ),
+                    shiny::actionButton(
                         "startup_load_qfeatures",
                         "Load QFeatures",
                         class = "btn-primary"
                     )
                 )
             ))
+        }
+
+        load_startup_qfeatures <- function(uploaded, selected_sets, workflow_steps) {
+            initial_idx <- tryCatch(
+                normalise_initial_sets(uploaded, selected_sets),
+                error = function(e) e
+            )
+            if (inherits(initial_idx, "error")) {
+                upload_message(conditionMessage(initial_idx))
+                return(invisible(NULL))
+            }
+
+            if (is.null(workflow_steps)) {
+                workflow_steps <- initial_steps
+            }
+
+            .qf$qfeatures <- format_qfeatures(uploaded, initial_idx)
+            global_rv$workflow_config <- workflow_steps
+            global_rv$code_lines <- list()
+            shiny::removeModal()
+
+            n_sets <- length(initial_idx)
+            n_steps <- length(workflow_steps)
+            shinyalert(
+                title = "QFeatures loaded",
+                text = paste0(
+                    "Loaded QFeatures with ", n_sets,
+                    " initial set", if (n_sets != 1) "s" else "", ".",
+                    if (n_steps > 0) {
+                        paste0(
+                            "\nWorkflow pre-configured with ", n_steps,
+                            " step", if (n_steps != 1) "s" else "", "."
+                        )
+                    } else {
+                        ""
+                    }
+                ),
+                closeOnClickOutside = TRUE,
+                type = "success",
+                confirmButtonCol = "#3c8dbc"
+            )
+
+            invisible(NULL)
         }
 
         shiny::observeEvent(input$startup_qfeatures_rds,
@@ -189,46 +237,44 @@ build_process_server <- function(qfeatures, initial_sets, initial_steps, has_qfe
                     return(invisible(NULL))
                 }
 
-                selected_sets <- input$startup_initial_sets
-                initial_idx <- tryCatch(
-                    normalise_initial_sets(uploaded, selected_sets),
-                    error = function(e) e
-                )
-                if (inherits(initial_idx, "error")) {
-                    upload_message(conditionMessage(initial_idx))
-                    return(invisible(NULL))
-                }
-
                 workflow_steps <- input[["workflow_config-workflow_list"]]
-                if (is.null(workflow_steps)) {
-                    workflow_steps <- initial_steps
-                }
-
-                .qf$qfeatures <- format_qfeatures(uploaded, initial_idx)
-                global_rv$workflow_config <- workflow_steps
-                global_rv$code_lines <- list()
-                shiny::removeModal()
-
-                n_sets <- length(initial_idx)
-                n_steps <- length(workflow_steps)
-                shinyalert(
-                    title = "QFeatures loaded",
-                    text = paste0(
-                        "Loaded QFeatures with ", n_sets,
-                        " initial set", if (n_sets != 1) "s" else "", ".",
-                        if (n_steps > 0) {
-                            paste0(
-                                "\nWorkflow pre-configured with ", n_steps,
-                                " step", if (n_steps != 1) "s" else "", "."
-                            )
-                        } else {
-                            ""
-                        }
-                    ),
-                    closeOnClickOutside = TRUE,
-                    type = "success",
-                    confirmButtonCol = "#3c8dbc"
+                load_startup_qfeatures(
+                    uploaded,
+                    input$startup_initial_sets,
+                    workflow_steps
                 )
+            },
+            ignoreInit = TRUE
+        )
+
+        shiny::observeEvent(input$startup_use_demo_qfeatures,
+            {
+                uploaded_qfeatures(NULL)
+                upload_message(NULL)
+                startup_reading(TRUE)
+                workflow_steps <- input[["workflow_config-workflow_list"]]
+
+                session$onFlushed(function() {
+                    demo_qfeatures <- tryCatch(
+                        demo_process_qfeatures(),
+                        error = function(e) e
+                    )
+                    startup_reading(FALSE)
+                    if (inherits(demo_qfeatures, "error")) {
+                        upload_message(paste(
+                            "Could not create demo QFeatures object:",
+                            conditionMessage(demo_qfeatures)
+                        ))
+                        return(invisible(NULL))
+                    }
+
+                    uploaded_qfeatures(demo_qfeatures)
+                    load_startup_qfeatures(
+                        demo_qfeatures,
+                        names(demo_qfeatures),
+                        workflow_steps
+                    )
+                }, once = TRUE)
             },
             ignoreInit = TRUE
         )

--- a/R/processQFeatures.R
+++ b/R/processQFeatures.R
@@ -45,25 +45,10 @@
 #'
 #' @examples
 #'
-#' # the example should be launched with `ask = FALSE`
-#'
-#' library(QFeatures)
 #' library(QFeaturesGUI)
 #'
-#' data("sampleTable")
-#' data("inputTable")
 #'
-#' qfeatures <- readQFeatures(
-#'     inputTable,
-#'     colData = sampleTable,
-#'     runCol = "Raw.file"
-#' )
-#'
-#' app <- processQFeatures(
-#'     qfeatures,
-#'     initialSets = seq_along(qfeatures),
-#'     maxSize = 100
-#' )
+#' app <- processQFeatures()
 #'
 #' if (interactive()) {
 #'     shiny::runApp(app)

--- a/R/utils_processQFeatures.R
+++ b/R/utils_processQFeatures.R
@@ -228,6 +228,41 @@ check_qfeatures <- function(qfeatures) {
     qfeatures
 }
 
+#' Build the bundled demo QFeatures object
+#'
+#' @return A \linkS4class{QFeatures} object built from the package
+#'   \code{inputTable} and \code{sampleTable} example datasets.
+#'
+#' @keywords internal
+#' @noRd
+demo_process_qfeatures <- function() {
+    data_env <- new.env(parent = emptyenv())
+    utils::data(
+        list = c("inputTable", "sampleTable"),
+        package = "QFeaturesGUI",
+        envir = data_env
+    )
+
+    if (!exists("inputTable", envir = data_env, inherits = FALSE) ||
+        !exists("sampleTable", envir = data_env, inherits = FALSE)) {
+        stop("Bundled demo data could not be loaded.")
+    }
+
+    qfeatures <- QFeatures::readQFeatures(
+        assayData = data_env$inputTable,
+        colData = data_env$sampleTable,
+        runCol = "Raw.file",
+        quantCols = NULL,
+        removeEmptyCols = TRUE,
+        verbose = FALSE
+    )
+    if (length(qfeatures) > 0) {
+        qfeatures <- QFeatures::zeroIsNA(qfeatures, i = seq_along(qfeatures))
+    }
+
+    qfeatures
+}
+
 #' Validate and map prefilled workflow steps
 #'
 #' Internal helper to validate workflow step identifiers and convert them

--- a/man/processQFeatures.Rd
+++ b/man/processQFeatures.Rd
@@ -54,25 +54,10 @@ applied to the selected assays.
 }
 \examples{
 
-# the example should be launched with `ask = FALSE`
-
-library(QFeatures)
 library(QFeaturesGUI)
 
-data("sampleTable")
-data("inputTable")
 
-qfeatures <- readQFeatures(
-    inputTable,
-    colData = sampleTable,
-    runCol = "Raw.file"
-)
-
-app <- processQFeatures(
-    qfeatures,
-    initialSets = seq_along(qfeatures),
-    maxSize = 100
-)
+app <- processQFeatures()
 
 if (interactive()) {
     shiny::runApp(app)

--- a/tests/testthat/test-shinytest2-processQFeatures.R
+++ b/tests/testthat/test-shinytest2-processQFeatures.R
@@ -161,6 +161,29 @@ run_filtering_module_export <- function(qfeatures, type, condition_specs) {
     exported
 }
 
+test_that("{shinytest2}: processQFeatures demo startup loads bundled QFeatures", {
+    testthat::skip_on_cran()
+
+    appObject <- QFeaturesGUI::processQFeatures(prefilledSteps = character())
+    app <- AppDriver$new(
+        appObject,
+        name = "processQFeatures_demo_startup",
+        height = 900,
+        width = 1200
+    )
+    on.exit(app$stop(), add = TRUE)
+
+    app$wait_for_idle()
+    app$click("startup_use_demo_qfeatures")
+    app$wait_for_idle(timeout = 30000)
+
+    logs <- app$get_logs()
+    testthat::expect_false(any(grepl(
+        "Can't access reactive value|Error in input",
+        logs$message
+    )))
+})
+
 test_that("{shinytest2} recording: processQFeatures", {
     testthat::skip_on_cran()
 

--- a/tests/testthat/test-utils-processQFeatures.R
+++ b/tests/testthat/test-utils-processQFeatures.R
@@ -73,6 +73,25 @@ test_that("check_qfeatures validates objects and RDS paths", {
     )
 })
 
+test_that("demo_process_qfeatures builds the bundled zero-to-NA demo object", {
+    data("inputTable", package = "QFeaturesGUI")
+    data("sampleTable", package = "QFeaturesGUI")
+
+    expected <- QFeatures::readQFeatures(
+        assayData = inputTable,
+        colData = sampleTable,
+        runCol = "Raw.file",
+        quantCols = NULL,
+        removeEmptyCols = TRUE,
+        verbose = FALSE
+    )
+    expected <- QFeatures::zeroIsNA(expected, i = seq_along(expected))
+
+    object <- demo_process_qfeatures()
+
+    expect_qfeatures_equal(object, expected)
+})
+
 test_that("check_prefilled_steps maps valid workflow identifiers", {
     expect_equal(
         check_prefilled_steps(c("sampleFiltering", "normalisation", "join")),

--- a/vignettes/processQFeatures.Rmd
+++ b/vignettes/processQFeatures.Rmd
@@ -52,7 +52,7 @@ The default is `seq_along(qfeatures)`.
 
 The app can be started without any parameter, in that case the app will start by asking you to load 
 an RDS containing a QFeatures object. Once loaded you can adjust the sets needed for the analysis
-of the object.
+of the object. Note that you can also use the "Use demo QFeatures" button to use an example QFeatures.
 
 # Workflow configuration
 


### PR DESCRIPTION
When launching processQFeatures without a QFeatures, the app opens with the QFeatures loader pop up. This pop up now has a "Use demo QFeatures" button that load a QFeatures built with `data(inputTable)` and `data(sampleTable)`.